### PR TITLE
T-53780 Fix Android build pipeline step: ci-bitrise-step-google-play-rollout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bitrise*
 _tmp/*
+venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+google-auth==2.35.0
+google-auth-oauthlib==1.2.1
+google-auth-httplib2==0.2.0
+google-api-python-client==2.149.0

--- a/step.sh
+++ b/step.sh
@@ -8,9 +8,9 @@ echo "Rolling out release for: ${package_name}"
 echo "Downloading credentials from service account file path"
 wget -O "${SCRIPT_DIR}/credentials.json" ${service_account_json_key_path}
 
-pipenv install google-api-python-client
-pipenv install oauth2client
+python3 --version
+pip3 install -r "${SCRIPT_DIR}/requirements.txt"
+python3 "${SCRIPT_DIR}/rollout.py" "${package_name}" "${SCRIPT_DIR}/credentials.json" "${track}"
 
-pipenv run python "${SCRIPT_DIR}/rollout.py" "${package_name}" "${SCRIPT_DIR}/credentials.json" "${track}"
-
+# Clean up
 rm "${SCRIPT_DIR}/credentials.json"

--- a/step.yml
+++ b/step.yml
@@ -22,7 +22,7 @@ host_os_tags:
 #
 project_type_tags:
   - android
-  
+
 # Type tags are used for categorizing steps, for easier step discovery in Step Libraries.
 # You can find more information about type tags in the Step Development Guideline:
 # https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md
@@ -31,32 +31,30 @@ type_tags:
 
 deps:
   brew:
-  - name: pipenv
   - name: wget
   apt_get:
-  - name: pipenv
   - name: wget
-  
+
 toolkit:
   bash:
     entry_file: step.sh
 
 
 inputs:
-  - service_account_json_key_path: 
+  - service_account_json_key_path:
     opts:
       title: Service Account JSON key file path
       summary: |-
         Path to the service account's JSON key file. It must be a secret environment variable, pointing to either a file uploaded to Bitrise or to a remote download location.
       is_required: true
       is_sensitive: true
-  - package_name: 
+  - package_name:
     opts:
       title: Package name
       summary: |-
         Package name of the app.
       is_required: true
-  - track: 
+  - track:
     opts:
       title: Track name
       summary: |-


### PR DESCRIPTION
# Description

1. Use whatever version of python3 comes with Ubuntu 20.04. Previously, we were using python 2.7. 
2. Drop dependency on `pipenv`. We don't need `pipenv` and it's just another package to maintain. Instead, let's just use `requirements.txt`.
3. `oauth2client` is deprecated. pypi recommends [google-auth](https://google-auth.readthedocs.io/) and [oauthlib](http://oauthlib.readthedocs.io/) instead.
